### PR TITLE
suggest user to upgrade weex-devtool directly

### DIFF
--- a/src/util/UpgradeNotice.js
+++ b/src/util/UpgradeNotice.js
@@ -10,7 +10,7 @@ exports.run = function () {
     npm.stdout.on('data', (data) => {
         let latestVersion = data.toString();
         if (getVersionValue(version) < getVersionValue(latestVersion)) {
-            console.log(LogStyle.dressUp('New version['+latestVersion+'] of Weex debugger detected! Please update weex-toolkit.(npm install -g weex-toolkit)', LogStyle.FG_RED))
+            console.log(LogStyle.dressUp('New version['+latestVersion+'] of Weex debugger detected! Please update.(npm install -g weex-devtool)', LogStyle.FG_RED))
         }
     });
 }


### PR DESCRIPTION
While weex-toolkit has upgraded to new architecture.  Every sub command  could/should upgrade  themselves instead depend on weex-toolkit update.