### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "exit": "^0.1.2",
     "ip": "^1.1.3",
     "koa": "^1.2.0",
+    "koa-bodyparser": "^2.3.0",
     "koa-router": "~5.2.3",
     "koa-serve": "~0.1.6",
     "koa-serve-static": "0.0.1",


### PR DESCRIPTION
Fix weex-devtool start with error because the lack of koa-bodyparser dependency in package.json